### PR TITLE
Remove references to the now-deprecated tsserverlibrary

### DIFF
--- a/Writing-a-Language-Service-Plugin.md
+++ b/Writing-a-Language-Service-Plugin.md
@@ -33,7 +33,7 @@ When your plugin is loaded, it's first initialized as a factory function with it
 
 Here's the minimal code that handles this injected `ts` value:
 ```ts
-function init(modules: { typescript: typeof import("typescript/lib/tsserverlibrary") }) {
+function init(modules: { typescript: typeof import("typescript") }) {
   const ts = modules.typescript;
   /* More to come here */
 }
@@ -47,7 +47,7 @@ TypeScript Language Service Plugins use the [Decorator Pattern](https://en.wikip
 
 Let's fill in some more code to properly set up a decorator:
 ```ts
-function init(modules: { typescript: typeof import("typescript/lib/tsserverlibrary") }) {
+function init(modules: { typescript: typeof import("typescript") }) {
   const ts = modules.typescript;
 
   function create(info: ts.server.PluginCreateInfo) {
@@ -167,7 +167,7 @@ function create(info: ts.server.PluginCreateInfo) {
 ## Putting it all together
 
 ```ts
-function init(modules: { typescript: typeof import("typescript/lib/tsserverlibrary") }) {
+function init(modules: { typescript: typeof import("typescript") }) {
   const ts = modules.typescript;
 
   function create(info: ts.server.PluginCreateInfo) {


### PR DESCRIPTION
In TypeScript 5.3, tsserverlibrary was replaced with a shim around the typescript import, and users were recommended to stop using it.

https://github.com/Microsoft/TypeScript/wiki/API-Breaking-Changes/

This makes that update for the wiki.